### PR TITLE
Ignore install pandas 2.1.0

### DIFF
--- a/github_contributions/setup.cfg
+++ b/github_contributions/setup.cfg
@@ -20,7 +20,7 @@ packages = find:
 package_dir = =src
 install_requires =
     requests>=2.0.0,<3.0.0
-    pandas>=2.0.0,<3.0.0
+    pandas>=2.0.0,!=2.1.0,<3.0.0  # 2.1.0 is missing a module
     frozendict>=2.0.0,<3.0.0
 python_requires = >=3.7
 


### PR DESCRIPTION
This version causes the [CI to fail](https://github.com/godatadriven/github-contributions/actions/runs/6037065836)