### PR TITLE
Set pandas analyze sample to 100000

### DIFF
--- a/profiles.yml
+++ b/profiles.yml
@@ -4,6 +4,8 @@ github:
     default:
       type: duckdb
       path: "{{ env_var('DUCKDB_PATH') }}"
+      settings:
+        pandas_analyze_sample: 100000
       plugins:
         - module: github_contributions.plugin
           alias: github_contributions


### PR DESCRIPTION
The [CI failed](https://github.com/godatadriven/github-contributions/actions/runs/6185171878/job/16790246924) due to type conversion. This setting increases the number of rows used for type conversion.