### PR TITLE
upgrade duckdb versions + change soda workflow trigger

### DIFF
--- a/.github/workflows/dbt.yml
+++ b/.github/workflows/dbt.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip
-          python -m pip install dbt-duckdb==1.6.0 github_contributions/
+          python -m pip install dbt-duckdb==1.7.0 github_contributions/
           dbt deps
 
       - name: dbt build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,8 +2,8 @@ name: Pull request checks
 
 on:
   pull_request:
-    paths-ignore:
-      - 'webapp/**'
+    paths:
+      - 'models/**'
 env:
   DUCKDB_PATH: github_contributions.duckdb
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'models/**'
+      - 'github_contributions/**'
 env:
   DUCKDB_PATH: github_contributions.duckdb
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -19,7 +19,7 @@
         "@mui/x-data-grid": "^6.14.0",
         "apexcharts": "^3.42.0",
         "date-fns": "^2.30.0",
-        "duckdb-wasm-kit": "^0.1.18",
+        "duckdb-wasm-kit": "0.1.24",
         "material-react-table": "^1.15.1",
         "react": "^18.2.0",
         "react-apexcharts": "^1.4.1",
@@ -434,99 +434,11 @@
       }
     },
     "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.27.1-dev125.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.27.1-dev125.0.tgz",
-      "integrity": "sha512-+1BMq8iAWM6W4UIrdu1bmu/eMskFnVAp/cCXozw9wsGStcKpgnoleWi5zJFcpaQggiIdwB/1NjhZ9LWryX5jqQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.28.0.tgz",
+      "integrity": "sha512-YaswpEmxr1Sp20/FZbWR7bZBJqj6xQXX2m4LLzYBnA02g4K1yrpxsBWmkxQyMbrH6AHKhcUUqAlaXfA2Rvaa3w==",
       "dependencies": {
         "apache-arrow": "^13.0.0"
-      }
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/@types/node": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
-      "integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ=="
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/apache-arrow": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-13.0.0.tgz",
-      "integrity": "sha512-3gvCX0GDawWz6KFNC28p65U+zGh/LZ6ZNKWNu74N6CQlKzxeoWHpi4CgEQsgRSEMuyrIIXi1Ea2syja7dwcHvw==",
-      "dependencies": {
-        "@types/command-line-args": "5.2.0",
-        "@types/command-line-usage": "5.0.2",
-        "@types/node": "20.3.0",
-        "@types/pad-left": "2.1.1",
-        "command-line-args": "5.2.1",
-        "command-line-usage": "7.0.1",
-        "flatbuffers": "23.5.26",
-        "json-bignum": "^0.0.3",
-        "pad-left": "^2.1.0",
-        "tslib": "^2.5.3"
-      },
-      "bin": {
-        "arrow2csv": "bin/arrow2csv.js"
-      }
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/array-back": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/command-line-usage": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.1.tgz",
-      "integrity": "sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==",
-      "dependencies": {
-        "array-back": "^6.2.2",
-        "chalk-template": "^0.4.0",
-        "table-layout": "^3.0.0",
-        "typical": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/flatbuffers": {
-      "version": "23.5.26",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
-      "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ=="
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/table-layout": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-3.0.2.tgz",
-      "integrity": "sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==",
-      "dependencies": {
-        "@75lb/deep-merge": "^1.1.1",
-        "array-back": "^6.2.2",
-        "command-line-args": "^5.2.1",
-        "command-line-usage": "^7.0.0",
-        "stream-read-all": "^3.0.1",
-        "typical": "^7.1.1",
-        "wordwrapjs": "^5.1.0"
-      },
-      "bin": {
-        "table-layout": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/typical": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
-      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/wordwrapjs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
-      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
-      "engines": {
-        "node": ">=12.17"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -1675,11 +1587,6 @@
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.2.tgz",
       "integrity": "sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg=="
     },
-    "node_modules/@types/flatbuffers": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@types/flatbuffers/-/flatbuffers-1.10.1.tgz",
-      "integrity": "sha512-Ljv5jhGc+SwSKZLuj9zkXkQXby6oX4VYWFgYIZqeXPvxzdgyBqJN9+u7d406XDow7ohulSxB8XhosLXN1dANKQ=="
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
@@ -1687,9 +1594,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.7.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
-      "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg=="
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
+      "integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ=="
     },
     "node_modules/@types/pad-left": {
       "version": "2.1.1",
@@ -2014,21 +1921,20 @@
       }
     },
     "node_modules/apache-arrow": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-11.0.0.tgz",
-      "integrity": "sha512-M8J4y+DimIyS44w2KOmVfzNHbTroR1oDpBKK6BYnlu8xVB41lxTz0yLmapo8/WJVAt5XcinAxMm14M771dm/rA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-13.0.0.tgz",
+      "integrity": "sha512-3gvCX0GDawWz6KFNC28p65U+zGh/LZ6ZNKWNu74N6CQlKzxeoWHpi4CgEQsgRSEMuyrIIXi1Ea2syja7dwcHvw==",
       "dependencies": {
         "@types/command-line-args": "5.2.0",
         "@types/command-line-usage": "5.0.2",
-        "@types/flatbuffers": "*",
-        "@types/node": "18.7.23",
+        "@types/node": "20.3.0",
         "@types/pad-left": "2.1.1",
         "command-line-args": "5.2.1",
-        "command-line-usage": "6.1.3",
-        "flatbuffers": "2.0.4",
+        "command-line-usage": "7.0.1",
+        "flatbuffers": "23.5.26",
         "json-bignum": "^0.0.3",
         "pad-left": "^2.1.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.5.3"
       },
       "bin": {
         "arrow2csv": "bin/arrow2csv.js"
@@ -2300,33 +2206,33 @@
       }
     },
     "node_modules/command-line-usage": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
-      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.1.tgz",
+      "integrity": "sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==",
       "dependencies": {
-        "array-back": "^4.0.2",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.2",
-        "typical": "^5.2.0"
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^3.0.0",
+        "typical": "^7.1.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.20.0"
       }
     },
     "node_modules/command-line-usage/node_modules/array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.17"
       }
     },
     "node_modules/command-line-usage/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
+      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.17"
       }
     },
     "node_modules/concat-map": {
@@ -2406,14 +2312,6 @@
         }
       }
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2454,13 +2352,13 @@
       }
     },
     "node_modules/duckdb-wasm-kit": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/duckdb-wasm-kit/-/duckdb-wasm-kit-0.1.18.tgz",
-      "integrity": "sha512-X02QT8j0XvubS07YX/ZykRLHh9Lz6cN3xZyOIC3Axdp39E5AS5uVrAtxVlstb3EssjJjfzlVqDVgyUIw4584iA==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/duckdb-wasm-kit/-/duckdb-wasm-kit-0.1.24.tgz",
+      "integrity": "sha512-iOTWhjKlgy/WpEM2NCCAvS625c23aSLFvJh+LQU8yv9WGAeMEIXZTVWuKcQBmzCS2EmUlYtSx/iW1zSHKM4Okg==",
       "dependencies": {
-        "@duckdb/duckdb-wasm": "^1.27.0",
+        "@duckdb/duckdb-wasm": "^1.28.0",
         "@holdenmatt/ts-utils": "^0.1.14",
-        "apache-arrow": "^11.0.0",
+        "apache-arrow": "^13.0.0",
         "react-async-hook": "^4.0.0"
       },
       "peerDependencies": {
@@ -2920,9 +2818,9 @@
       }
     },
     "node_modules/flatbuffers": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-2.0.4.tgz",
-      "integrity": "sha512-4rUFVDPjSoP0tOII34oQf+72NKU7E088U5oX7kwICahft0UB2kOQ9wUzzCp+OHxByERIfxRDCgX5mP8Pjkfl0g=="
+      "version": "23.5.26",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
+      "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ=="
     },
     "node_modules/flatted": {
       "version": "3.2.9",
@@ -3776,14 +3674,6 @@
         "react-dom": ">=16.6.0"
       }
     },
-    "node_modules/reduce-flatten": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
@@ -4126,33 +4016,39 @@
       }
     },
     "node_modules/table-layout": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
-      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-3.0.2.tgz",
+      "integrity": "sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==",
       "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
+        "@75lb/deep-merge": "^1.1.1",
+        "array-back": "^6.2.2",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.0",
+        "stream-read-all": "^3.0.1",
+        "typical": "^7.1.1",
+        "wordwrapjs": "^5.1.0"
+      },
+      "bin": {
+        "table-layout": "bin/cli.js"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.17"
       }
     },
     "node_modules/table-layout/node_modules/array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.17"
       }
     },
     "node_modules/table-layout/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
+      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.17"
       }
     },
     "node_modules/text-table": {
@@ -4353,23 +4249,11 @@
       }
     },
     "node_modules/wordwrapjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
-      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.2.0"
-      },
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
+      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
       "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/wordwrapjs/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "engines": {
-        "node": ">=8"
+        "node": ">=12.17"
       }
     },
     "node_modules/wrappy": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,7 +23,7 @@
     "@mui/x-data-grid": "^6.14.0",
     "apexcharts": "^3.42.0",
     "date-fns": "^2.30.0",
-    "duckdb-wasm-kit": "^0.1.18",
+    "duckdb-wasm-kit": "0.1.24",
     "material-react-table": "^1.15.1",
     "react": "^18.2.0",
     "react-apexcharts": "^1.4.1",
@@ -44,7 +44,4 @@
     "typescript": "^5.0.2",
     "vite": "^4.4.5"
   },
-  "overrides": {
-    "@duckdb/duckdb-wasm": "1.27.1-dev125.0"
-  }
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -43,5 +43,5 @@
     "eslint-plugin-react-refresh": "^0.4.3",
     "typescript": "^5.0.2",
     "vite": "^4.4.5"
-  },
+  }
 }


### PR DESCRIPTION
solves https://github.com/godatadriven/github-contributions/issues/46

- So everything will use storage version 64 of the internal duckdb database (https://duckdb.org/internals/storage.html)
- only run the soda flow when you actual change dbt or plugin code

(both duckdb-wasm-kit 0.1.24 and dbt-duckdb 1.7.0 seem to use a 9.x version of duckdb)

### Checklist

- [ ] When adding a Github handle to be tracked that is not yours, request the user to approve the PR
