### PR TITLE
increase job timeout to 7 days

### DIFF
--- a/.github/workflows/dbt.yml
+++ b/.github/workflows/dbt.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   dbt:
     runs-on: self-hosted
+    timeout-minutes: 10080
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
### Checklist
You need to manually increase the job timeout when running on a self-hosted runner:

See: https://github.com/orgs/community/discussions/26679
and https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

- [ ] When adding a Github handle to be tracked that is not yours, request the user to approve the PR
