### PR TITLE
Revert "Caching age 1 week"

### DIFF
--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -5,10 +5,5 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   assetsInclude: ['src/assets/github_contributions.duckdb'],
   plugins: [react()],
-  base: '/github-contributions/',
-  server: {
-    headers: {
-      'Cache-Control': 'public, max-age=604800, immutable'
-    }
-  }
+  base: '/github-contributions/'
 });


### PR DESCRIPTION
Reverts godatadriven/github-contributions#93

Apparently this is fully managed by github pages, and this is only for the local dev server:
https://webapps.stackexchange.com/questions/119286/caching-assets-in-website-served-from-github-pages