### PR TITLE
Change upload artifact action due to deprecation

### DIFF
--- a/.github/workflows/dbt.yml
+++ b/.github/workflows/dbt.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload duckdb for Debugging
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: github_contributions_debug_${{ github.run_id }}.duckdb
           path: ${{ env.DUCKDB_PATH }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload duckdb
         if: ${{ success() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: github_contributions.duckdb
           path: ${{ env.DUCKDB_PATH }}

--- a/.github/workflows/deploy_dashboard_to_github_pages.yml
+++ b/.github/workflows/deploy_dashboard_to_github_pages.yml
@@ -59,7 +59,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           name: github-pages
           path: ${{ env.WORKING_DIRECTORY }}/dist

--- a/.github/workflows/upload_duckdb_database_to_motherduck.yml
+++ b/.github/workflows/upload_duckdb_database_to_motherduck.yml
@@ -17,7 +17,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Download duckdb
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/upload_duckdb_database_to_motherduck.yml
+++ b/.github/workflows/upload_duckdb_database_to_motherduck.yml
@@ -17,7 +17,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
       - name: Download duckdb
         uses: dawidd6/action-download-artifact@v2


### PR DESCRIPTION
- v2 of all upload artifact github actions are deprecated, advice is to upgrade to v4.
see: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

test run: https://github.com/godatadriven/github-contributions/actions/runs/10815654359

### Checklist

- [ ] When adding a Github handle to be tracked that is not yours, request the user to approve the PR
